### PR TITLE
Error produced by not having database available

### DIFF
--- a/content/docs/tutorials/automatic-prisma-migrations.mdx
+++ b/content/docs/tutorials/automatic-prisma-migrations.mdx
@@ -90,7 +90,7 @@ npx prisma migrate dev --name init
 
 This Prisma command replays the existing migration history in the shadow database, applies pending migrations, generates a new migration from any changes you made, applies all unapplicated migrations to the development branch, and updates the `_prisma_migrations` table.
 
-The `prisma migrate dev` command will create a SQL file like `prisma/migrations/20210806002614_init/migration.sql` (the exact folder will match the current timestamp and name).
+The `prisma migrate dev` command will create a SQL file like `prisma/migrations/20210806002614_init/migration.sql` (the exact folder will match the current timestamp and name). If your account doesn't have a databased named `prisma-playground` yet, you should run `npx prisma db push`.
 
 <InfoBlock type='tip'>
   You can learn more about the <inlineCode>prisma migrate dev</inlineCode> command in the{' '}


### PR DESCRIPTION
As I was following the tutorial I got stuck on step 5. This [great video](https://youtu.be/M5Uq6Gu51Xo?t=391) saved my day.

This is the error I was getting: 
```
Environment variables loaded from .env
Prisma schema loaded from prisma/schema.prisma
Datasource "db": MySQL database "prisma-playground" at "127.0.0.1:3309"

Error: P3014

Prisma Migrate could not create the shadow database. Please make sure the database user has permission to create databases. Read more about the shadow database (and workarounds) at https://pris.ly/d/migrate-shadow

Original error: 
create database is not supported
   0: sql_migration_connector::flavour::mysql::sql_schema_from_migration_history
             at migration-engine/connectors/sql-migration-connector/src/flavour/mysql.rs:420
   1: migration_core::api::DevDiagnostic
             at migration-engine/core/src/api.rs:108

```
The explanation might be incorrect, suggestions are welcomed!