### PR TITLE
Minor update to nextjs-planetscale-netlify-template docs

### DIFF
--- a/content/docs/tutorials/nextjs-planetscale-netlify-template.mdx
+++ b/content/docs/tutorials/nextjs-planetscale-netlify-template.mdx
@@ -180,7 +180,7 @@ pscale shell netlify-starter main
 Once in the shell, view the tables with:
 
 ```bash
-SHOW tables
+SHOW tables;
 ```
 
 Type `exit` to exit the MySQL shell.


### PR DESCRIPTION
Add semicolon to end of `SHOW tables` database statement so that query executes.

`SHOW tables;`

If you don't the query will hang, might confuse some people.
![image](https://user-images.githubusercontent.com/10026538/142724243-e6961c35-7d48-47f6-858b-1517ec6e3b82.png)

Now with semicolon™️
![image](https://user-images.githubusercontent.com/10026538/142724268-43105c37-49a5-45f3-93f4-b4163b414c87.png)