### PR TITLE
Add automatically copy migration data with Prisma

### DIFF
--- a/content/docs/tutorials/prisma-quickstart.mdx
+++ b/content/docs/tutorials/prisma-quickstart.mdx
@@ -34,6 +34,10 @@ For the `REGION` value, choose the region closest to you or your application's h
 
 Your database will deploy with an initial development branch, `main`.
 
+Now that your database is created, you can get PlanetsScale to track your migration table.
+
+Click on your `star-app` database in the dashboard and then click on the **"Settings"** tab in the top nav. Check **"Automatically copy migration data"** and then select **"Prisma"** as your migration framework. Don't forget to click on **"Save database settings"** to save your changes.
+
 ### Set up branches
 
 Now that you have your PlanetScale database set up, you need to create a development branch to connect to your Prisma application.


### PR DESCRIPTION
I was going through the "Prisma with PlanetScale quickstart" guide today and noticed that it's missing the automatically copy migration data setting. I am not sure if this setting no longer serves its purpose after `prisma migrate` was changed to `db push` but just in case I decided to bring it up.

Thank you for your time! 