### PR TITLE
User `--region` flag in nextjs-planetscale-netlify-template.mdx example

### DIFF
--- a/content/docs/tutorials/nextjs-planetscale-netlify-template.mdx
+++ b/content/docs/tutorials/nextjs-planetscale-netlify-template.mdx
@@ -190,7 +190,7 @@ The final step in the site deployment is configuring your production environment
 
 Click on the "**Edit variables**" button and enter in the following key/value pairs:
 
-- `DATABASE_URL` &mdash; To find this value, go back to your PlanetScale dashboard, click on the `netlify-starter` database, and select the `main` branch under "**Branches**". Click on the "**Connect**" dropdown and then click the "**Generate new password**" button. Next, click on the "**General**"" dropdown in that modal and select "**Prisma**". Copy the value for `url` and paste that back in the Netlify dashboard as the value for `DATABASE_URL`. Be sure to save your PlanetScale password somewhere as you won't be able to access it again after closing the modal.
+- `DATABASE_URL` &mdash; To find this value, go back to your PlanetScale dashboard, click on the `netlify-starter` database, and select the `main` branch under "**Branches**". Click on the "**Connect**" dropdown and then click the "**Generate new password**" button. Next, click on the "**General**" dropdown in that modal and select "**Prisma**". Copy the value for `url` and paste that back in the Netlify dashboard as the value for `DATABASE_URL`. Be sure to save your PlanetScale password somewhere as you won't be able to access it again after closing the modal.
 - `NEXTAUTH_SECRET` &mdash; You may have already filled this out, but if not generate a new secret at [https://generate-secret.now.sh/32](https://generate-secret.now.sh/32) and paste in the value that's returned.
 - `NEXTAUTH_URL` &mdash; Paste in the Netlify site name that was generated for you. For example, `https://stoic-lumiere-6df10.netlify.app`
 

--- a/content/docs/tutorials/nextjs-planetscale-netlify-template.mdx
+++ b/content/docs/tutorials/nextjs-planetscale-netlify-template.mdx
@@ -82,7 +82,7 @@ In the dashboard, click on the "**Create a database**" button. Name your databas
 Alternatively, [sign in and create a database with the CLI](/tutorials/planetscale-quick-start-guide#quick-start-with-the-planetscale-cli) by running the following:
 
 ```bash
-pscale database create <database-name> -regionSlug
+pscale database create <database-name> --region <region-slug>
 ```
 
 The list of region slugs can be found in our [Regions documentation](https://docs.planetscale.com/concepts/regions#available-regions).


### PR DESCRIPTION
Old bash command ignores region and always creates database in US East. Added --region flag to fix this. 

Also removed double double quotes after `**General**`.