### PR TITLE
Update link for CLI quick start guide

### DIFF
--- a/content/docs/tutorials/planetscale-quick-start-guide.mdx
+++ b/content/docs/tutorials/planetscale-quick-start-guide.mdx
@@ -14,7 +14,7 @@ The following guide will show you how to:
 
 If you already have your PlanetScale database set up, you may find the [Connecting your application](/tutorials/connect-any-application) or [Branching](/concepts/branching) guides more helpful.
 
-This guide is split up so that you can either follow it in the [PlanetScale dashboard](#getting-started-—-planetscale-dashboard) or using the [PlanetScale CLI](##getting-started-—-planetscale-cli).
+This guide is split up so that you can either follow it in the [PlanetScale dashboard](#getting-started-—-planetscale-dashboard) or using the [PlanetScale CLI](#getting-started-—-planetscale-cli).
 
 <VideoBlock src='/img/docs/ps-quickstart-demo.mp4' />
 <p align='center'><i>Video shows a demo in the PlanetScale dashboard of everything covered in this guide.</i></p>


### PR DESCRIPTION
Hello, 

Currently the link for the pscale quickstart cli doesn't work because there is an extra `#` in the markdown link.

Removing it allows the user to jump to the cli quick start section. That is all 😃 

Thank you