### PR TITLE
Fixed the Key error Problem

### DIFF
--- a/content/docs/tutorials/connect-django-app.mdx
+++ b/content/docs/tutorials/connect-django-app.mdx
@@ -93,7 +93,7 @@ Take note of the values returned to you, as you won't be able to see this passwo
 ```
 DB_HOST=<ACCESS HOST URL>
 DB_PORT=3306
-DB_DATABASE=<DATABASE_NAME>
+DB_NAME=<DATABASE_NAME>
 DB_USER=<USERNAME>
 DB_PASSWORD=<PLAIN TEXT>
 MYSQL_ATTR_SSL_CA=/etc/ssl/cert.pem


### PR DESCRIPTION
The settings file calls DB_NAME which is not present in the env file. This also exists in the website's dashboard example.