### PR TITLE
Update go tutorial, remove mysql from DSN template

### DIFF
--- a/content/docs/tutorials/connect-go-app.mdx
+++ b/content/docs/tutorials/connect-go-app.mdx
@@ -92,7 +92,7 @@ Take note of the values returned to you, as you won't be able to see this passwo
 2. Open the `.env` file in your Go app and update `DSN` as follows:
 
 ```
-DSN="mysql://<USERNAME>:<PASSWORD>@tcp(<ACCESS HOST URL>)/<DATABASE_NAME>?tls=true"
+DSN="<USERNAME>:<PASSWORD>@tcp(<ACCESS HOST URL>)/<DATABASE_NAME>?tls=true"
 ```
 
 Fill in `USERNAME`, `PASSWORD`, `ACCESS HOST URL`, and `DATABASE_NAME` with the appropriate values from the CLI output above. Do not remove the parentheses around the access host URL.


### PR DESCRIPTION
- Created password with CLI
- Filled the template
- Was not able to connect until i removed `mysql://` from DSN within `.env` file

Here's a corresponding PR on golang example repo
https://github.com/planetscale/golang-example/pull/5

The console produces DSN **format without leading mysql** part
![image](https://user-images.githubusercontent.com/4247206/184711701-d07fccfb-aba7-4449-9995-6adc50114a45.png)
