### PR TITLE
fix typo in prisma-quickstart.mdx

### DIFF
--- a/docs/tutorials/prisma-quickstart.mdx
+++ b/docs/tutorials/prisma-quickstart.mdx
@@ -127,7 +127,7 @@ DATABASE_URL = 'mysql://root@127.0.0.1:3309/<DATABASE_NAME>'
 
 ## Connect to PlanetScale
 
-Now you need to locally proxy into your PlanetScale database branches using the PlanetScale CLI. In a seperate terminal, run the following commands:
+Now you need to locally proxy into your PlanetScale database branches using the PlanetScale CLI. In a separate terminal, run the following commands:
 
 ```bash
 pscale connect star-app initial-setup --port 3309


### PR DESCRIPTION
seperate => separate