### PR TITLE
Update `referentialIntegrity` to `relationMode` for Prisma `4.7.0`

### DIFF
--- a/docs/tutorials/automatic-prisma-migrations.mdx
+++ b/docs/tutorials/automatic-prisma-migrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Automatic Prisma migrations'
 subtitle: 'How to make changes to your PlanetScale database schema while using Prisma, a next-generation Node.js and TypeScript ORM'
-date: '2022-08-01'
+date: '2022-11-29'
 ---
 
 import InfoBlock from '@/components/MDX.InfoBlock'
@@ -62,6 +62,10 @@ pscale connect prisma-playground main --port 3309
 </InfoBlock>
 
 3. Update your `prisma/schema.prisma` file with the following schema:
+
+<InfoBlock type='note'>
+  In Prisma `4.5.0`, `referentialIntegrity` changed to `relationMode` and became generally available in `4.7.0`. The following schema reflects this change.
+</InfoBlock>
 
 ```
 datasource db {

--- a/docs/tutorials/automatic-prisma-migrations.mdx
+++ b/docs/tutorials/automatic-prisma-migrations.mdx
@@ -67,7 +67,7 @@ pscale connect prisma-playground main --port 3309
   In Prisma `4.5.0`, `referentialIntegrity` changed to `relationMode` and became generally available in `4.7.0`. The following schema reflects this change.
 </InfoBlock>
 
-```
+```js
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")

--- a/docs/tutorials/automatic-prisma-migrations.mdx
+++ b/docs/tutorials/automatic-prisma-migrations.mdx
@@ -67,12 +67,11 @@ pscale connect prisma-playground main --port 3309
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
-  referentialIntegrity = "prisma"
+  relationMode = "prisma"
 }
 
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["referentialIntegrity"]
 }
 
 model Post {

--- a/docs/tutorials/prisma-data-platform-integration.mdx
+++ b/docs/tutorials/prisma-data-platform-integration.mdx
@@ -61,13 +61,12 @@ Next, you need to connect your Prisma project to your PlanetScale database. Here
 ```js
 generator client {
   provider        = "prisma-client-js" //If you want to use TypeScript, use "prisma-client-ts"
-  previewFeatures = ["referentialIntegrity"]
 }
 
 datasource db {
   provider             = "mysql"
   url                  = env("DATABASE_URL")
-  referentialIntegrity = "prisma"
+  relationMode = "prisma"
 }
 ```
 

--- a/docs/tutorials/prisma-data-platform-integration.mdx
+++ b/docs/tutorials/prisma-data-platform-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'PlanetScale and Prisma Data Platform integration'
 subtitle: 'Use the Prisma Data Platform to auto-generate a project with Prisma and PlanetScale and deploy it to Vercel.'
-date: '2022-09-28'
+date: '2022-11-29'
 ---
 
 import ImageBlock from '@/components/MDX.ImageBlock'
@@ -56,6 +56,10 @@ Next, you need to connect your Prisma project to your PlanetScale database. Here
 
 <InfoBlock type="note">
   If you are using an existing Prisma project, you can skip updating the schema in steps 9 and 10.
+</InfoBlock>
+
+<InfoBlock type='note'>
+  In Prisma `4.5.0`, `referentialIntegrity` changed to `relationMode` and became generally available in `4.7.0`. The following schema reflects this change.
 </InfoBlock>
 
 ```js

--- a/docs/tutorials/prisma-quickstart.mdx
+++ b/docs/tutorials/prisma-quickstart.mdx
@@ -1,12 +1,13 @@
 ---
 title: 'Prisma with PlanetScale quickstart'
 subtitle: 'Learn how to integrate Prisma with PlanetScale'
-date: '2022-07-22'
+date: '2022-11-29'
 ---
 
 import ImageBlock from '@/components/MDX.ImageBlock'
 import schema from '@/images/prisma-quickstart--schema.png'
 import studio from '@/images/prisma-quickstart--studio.png'
+import InfoBlock from '@/components/MDX.InfoBlock'
 
 ## Overview
 
@@ -96,6 +97,10 @@ npx prisma init
 ```
 
 This creates the `prisma` directory with a file named `schema.prisma`. This file will hold your [Prisma schema configuration](https://www.prisma.io/docs/concepts/components/prisma-schema), which includes your data sources (PlanetScale), generators ([Prisma Client](https://www.prisma.io/docs/concepts/components/prisma-client)), and data models.
+
+<InfoBlock type='note'>
+  In Prisma `4.5.0`, `referentialIntegrity` changed to `relationMode` and became generally available in `4.7.0`. The following schema reflects this change.
+</InfoBlock>
 
 Open up the `prisma/schema.prisma` file and paste in the following:
 

--- a/docs/tutorials/prisma-quickstart.mdx
+++ b/docs/tutorials/prisma-quickstart.mdx
@@ -103,12 +103,11 @@ Open up the `prisma/schema.prisma` file and paste in the following:
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
-  referentialIntegrity = "prisma"
+  relationMode = "prisma"
 }
 
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["referentialIntegrity"]
 }
 
 model Star {


### PR DESCRIPTION
Hey folks 👋  

We have made some changes to the feature previously known as Referential Integrity. 

1. This feature has been renamed to “****Relation mode”**** in Prisma 4.5.0. 
2. This feature will become [Generally Available](https://www.prisma.io/docs/about/prisma/releases#generally-available-ga) in Prisma 4.7.0, which will be released next Tuesday (29th November).

You can learn more about this change in the [documentation](https://www.prisma.io/docs/concepts/components/prisma-schema/relations/relation-mode) and [release notes](https://github.com/prisma/prisma/releases).

Making this PR to update the docs and to give you a heads-up on this change. 


If you have any questions or if any further modifications are needed, please let me know. Additionally, please only merge this _after_ Prisma 4.7.0 is released on 29th November. 

