### PR TITLE
add link to Prisma Relation mode docs

### DIFF
--- a/docs/tutorials/automatic-prisma-migrations.mdx
+++ b/docs/tutorials/automatic-prisma-migrations.mdx
@@ -65,6 +65,8 @@ pscale connect prisma-playground main --port 3309
 
 <InfoBlock type='note'>
   In Prisma `4.5.0`, `referentialIntegrity` changed to `relationMode` and became generally available in `4.7.0`. The following schema reflects this change.
+  You can learn more about Prisma's Relation mode in the{' '}
+  <a href='https://www.prisma.io/docs/concepts/components/prisma-schema/relations/relation-mode'>Prisma docs</a>.
 </InfoBlock>
 
 ```js

--- a/docs/tutorials/prisma-data-platform-integration.mdx
+++ b/docs/tutorials/prisma-data-platform-integration.mdx
@@ -60,6 +60,8 @@ Next, you need to connect your Prisma project to your PlanetScale database. Here
 
 <InfoBlock type='note'>
   In Prisma `4.5.0`, `referentialIntegrity` changed to `relationMode` and became generally available in `4.7.0`. The following schema reflects this change.
+  You can learn more about Prisma's Relation mode in the{' '}
+  <a href='https://www.prisma.io/docs/concepts/components/prisma-schema/relations/relation-mode'>Prisma docs</a>.
 </InfoBlock>
 
 ```js

--- a/docs/tutorials/prisma-quickstart.mdx
+++ b/docs/tutorials/prisma-quickstart.mdx
@@ -100,6 +100,8 @@ This creates the `prisma` directory with a file named `schema.prisma`. This file
 
 <InfoBlock type='note'>
   In Prisma `4.5.0`, `referentialIntegrity` changed to `relationMode` and became generally available in `4.7.0`. The following schema reflects this change.
+  You can learn more about Prisma's Relation mode in the{' '}
+  <a href='https://www.prisma.io/docs/concepts/components/prisma-schema/relations/relation-mode'>Prisma docs</a>.
 </InfoBlock>
 
 Open up the `prisma/schema.prisma` file and paste in the following:


### PR DESCRIPTION
Follows https://github.com/planetscale/docs/pull/223
We now have a dedicated page in Prisma's docs, I thought it would be a great addition where `relationMode` is mentioned