### PR TITLE
docs(tutorials): fix typo

### DIFF
--- a/docs/tutorials/planetscale-serverless-driver-node-example.mdx
+++ b/docs/tutorials/planetscale-serverless-driver-node-example.mdx
@@ -74,7 +74,7 @@ If you are using Windows, run this command through the [Windows Subsystem for Li
 
 </InfoBlock>
 
-Create a new file file named `.env` in the root of the project and paste in the sample provided from PlanetScale.
+Create a new file named `.env` in the root of the project and paste in the sample provided from PlanetScale.
 
 <ImageBlock alt='The .env example.' src={img6} />
 


### PR DESCRIPTION
fix typo in planetscale-serverless-driver-node-example.mdx