### PR TITLE
Fix broken image source for query insights list

### DIFF
--- a/docs/concepts/billing.md
+++ b/docs/concepts/billing.md
@@ -158,7 +158,7 @@ The `SELECT count(*)` query is a special case. The database engine optimizes thi
 
 With our in-dashboard [Insights tool](/docs/concepts/query-insights), you can explore active queries running against your database. The "**Queries during the last 24 hours**" list has a column that shows the total rows read for that particular query. The "rows read" surfaced here is the same number we use to calculate your total rows read for your billing calculation. In addition, you can click on a particular query to see more information about its performance.
 
-![PlanetScale Insights recent queries list](/docs/concepts/billing//docs/concepts/query-insights/queries.png)
+![PlanetScale Insights recent queries list](/docs/concepts/query-insights/queries.png)
 
 If you'd prefer to test a query on your own, you can calculate the **approximate** rows read using the `EXPLAIN` statement. Running `EXPLAIN` with your query will return information about the query execution plan.
 


### PR DESCRIPTION
When you scroll down to this part of the [Concepts > Billing](https://planetscale.com/docs/concepts/billing) page, there's an up and down jitter in Firefox due to repeated failing attempts to load the the queries list screenshot. I noticed that the image URL is probably supposed to be [docs/concepts/query-insights/queries.png](https://planetscale-images.imgix.net/docs/concepts/query-insights/queries.png?auto=compress%2Cformat).