### PR TITLE
update two pages to reflect updated interface

### DIFF
--- a/docs/onboarding/create-a-database.md
+++ b/docs/onboarding/create-a-database.md
@@ -41,28 +41,15 @@ Next, you’ll be dropped into the dashboard for that specific database. Let's t
 2. **Deploy requests** &mdash; How you apply changes to your database schema. More on that in the next article.
 3. **Branches** &mdash; View the different branches of your database. Again, more on that in the next article.
 4. **Insights** &mdash; Provides statistics on database operations that may be affecting performance.
-5. **Backups** &mdash; Shows you backup schedule and all backups for this database across production and development branches.
-6. **Settings** &mdash; Lets you tweak various aspects of your database like who has access to it, beta feature opt-ins, and plan management.
-7. **Connect** &mdash; Provides connection details that applications can use to connect to your database.
-8. **New branch** &mdash; Allows you to create a new branch of your schema.
+5. **Console** &mdash; Lets you run MySQL commands against branches.
+6. **Backups** &mdash; Shows you backup schedule and all backups for this database across production and development branches.
+7. **Settings** &mdash; Lets you tweak various aspects of your database like who has access to it, beta feature opt-ins, and plan management.
 
 ![The dashboard of a database on PlanetScale.](/docs/onboarding/create-a-database/the-dashboard-of-a-database-on-planetscale.png)
 
-Now let’s add a table and some columns to the database. PlanetScale databases leverage branches to let you create copies of your database so you can safely experiment with the schema without affecting your main production database. Branches will be covered more in detail in the next article, but since they are an integral part of the system, you’ll always be working within a database branch. The default branch created for all databases is `main`. Click on **"Branches"**, then select `main` from the list.
+Now let’s add a table and some columns to the database. PlanetScale databases leverage branches to let you create copies of your database so you can safely experiment with the schema without affecting your main production database. Branches will be covered more in detail in the next article, but since they are an integral part of the system, you’ll always be working within a database branch. The default branch created for all databases is `main`. Click on **"Console"** to get access to an in-browser MySQL shell, by default your `main` database is selected. Click **"Connect"**.
 
-![The default list of branches after creating a database.](/docs/onboarding/create-a-database/the-default-list-of-branches-after-creating-a-database.png)
-
-You should notice the breadcrumbs have changed to include the name of the database, as well as the tabs in the top nav.
-
-1. **Overview** &mdash; The current view showing the branch overview.
-2. **Console** &mdash; Lets you run MySQL commands against this branch.
-3. **Schema** &mdash; Shows the active schema of the branch.
-4. **Insights** &mdash; Provides statistics on database operations for the branch.
-5. The option to promote a branch to production.
-
-![The dashboard of a database branch on PlanetScale.](/docs/onboarding/create-a-database/the-dashboard-of-a-database-branch-on-planetscale.png)
-
-Click on **"Console"** to get access to an in-browser MySQL shell for the selected database branch. Run the following command in that console to create your first table:
+Run the following command in that console to create your first table:
 
 ```sql
 CREATE TABLE hotels(

--- a/docs/tutorials/planetscale-quick-start-guide.md
+++ b/docs/tutorials/planetscale-quick-start-guide.md
@@ -16,13 +16,13 @@ The following guide will show you how to:
 
 If you already have your PlanetScale database set up, you may find the [Connecting your application](/docs/tutorials/connect-any-application) or [Branching](/docs/concepts/branching) guides more helpful.
 
-This guide is split up so that you can either follow it in the [PlanetScale dashboard](#getting-started-—-planetscale-dashboard) or using the [PlanetScale CLI](#getting-started-—-planetscale-cli).
+This guide is split up so that you can either follow it in the [PlanetScale dashboard](#getting-started--planetscale-dashboard) or using the [PlanetScale CLI](#getting-started--planetscale-cli).
 
 {% vimeo src="https://player.vimeo.com/video/763913923" caption="A video demo of everything covered in this guide" /%}
 
 ## Getting started &mdash; PlanetScale dashboard
 
-You'll need [ a PlanetScale account](https://auth.planetscale.com/sign-up) to complete this guide.
+You'll need [a PlanetScale account](https://auth.planetscale.com/sign-up) to complete this guide.
 
 ### Create a database
 
@@ -41,13 +41,12 @@ Your database is created with an [**initial development branch**](/docs/concepts
 
 This quickstart demonstrates how to create and use two relational tables: `categories` and `products`.
 
-1. From your database's overview page, click on the "**Branches**" tab in the database navigation.
+1. From your database's overview page, click on the "**Console**" tab in the database navigation. This will open up a [web console](/docs/concepts/web-console) connected to your database branch.
 
 ![Branches](/docs/tutorials/planetscale-quick-start-guide/branches.png)
 
-2. Click on the `main` branch.
-3. Click on the "**Console**" tab. This will open up a [web console](/docs/concepts/web-console) connected to your database branch.
-4. Create the `categories` and `products` tables by running the following commands in the web console:
+2. By default the `main` branch is preselected. Click **"Connect"**.
+3. Create the `categories` and `products` tables by running the following commands in the web console:
 
 ```sql
 CREATE TABLE categories (


### PR DESCRIPTION
I noticed my interface does not match the interface displayed in the guides, this is why I edited two documents, see PR files

here are images I did not replace, if I would they would contain info about my account and not match the others on the page:
* image: `/docs/onboarding/create-a-database/the-dashboard-of-a-database-on-planetscale.png` from the document: `/onboarding/create-a-database.md` still needs to get updated if this PR gets accepted
* image 2: `/docs/tutorials/planetscale-quick-start-guide/branches.png` from the document: `/tutorials/planetscale-quick-start-guide.md` needs to get updated too

I just changed the text, but there are also the videos on those two pages show an interface that doesn't match the documentation, maybe you want to edit those too at some point

I also fixed a few URLs that my linter (<https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint>) told me are wrong, finally I also wanted to mention that the linter shows warning in the page `/tutorials/planetscale-quick-start-guide.md` regarding duplicate headers <https://github.com/DavidAnson/markdownlint/blob/v0.27.0/doc/md024.md>, I however did not change them as as I did not know how, I let you decide if this has to be done or can be ignored, I mean if they are not used for internal links it doesn't matter if they are duplicate so maybe you want to keep them short