### PR TITLE
Skip checks for downstream script

### DIFF
--- a/script/sync-upstream.sh
+++ b/script/sync-upstream.sh
@@ -80,7 +80,7 @@ git status
 
 echo "[+] git diff-index:"
 # git diff-index : to avoid doing the git commit failing if there are no changes to be commit
-git diff-index --quiet HEAD || git commit --message 'docs: downstream' --message "https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA" --message $'\nskip-check: true' --cleanup=verbatim
+git diff-index --quiet HEAD || git commit --message 'docs: downstream' --message "https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA" --message $'\nskip-checks: true' --cleanup=verbatim
 
 echo "[+] Pushing git commit"
 # --set-upstream: sets the branch when pushing to a branch that does not exist

--- a/script/sync-upstream.sh
+++ b/script/sync-upstream.sh
@@ -80,7 +80,7 @@ git status
 
 echo "[+] git diff-index:"
 # git diff-index : to avoid doing the git commit failing if there are no changes to be commit
-git diff-index --quiet HEAD || git commit --message 'docs: downstream' --message "https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
+git diff-index --quiet HEAD || git commit --message 'docs: downstream' --message "https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA" --message $'\nskip-check: true' --cleanup=verbatim
 
 echo "[+] Pushing git commit"
 # --set-upstream: sets the branch when pushing to a branch that does not exist


### PR DESCRIPTION
Currently, downstream action is throwing `error: Required status check "lint" is expected.`

Since it's just a sync, we should be able to just [skip checks for the sync commit](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#skipping-and-requesting-checks-for-individual-commits)