### PR TITLE
Fix index name in operating without FKs

### DIFF
--- a/docs/learn/operating-without-foreign-key-constraints.md
+++ b/docs/learn/operating-without-foreign-key-constraints.md
@@ -105,7 +105,7 @@ CREATE TABLE child_table (
 
 {% callout type="tip" %}
 Each FOREIGN KEY constraint requires an index covering the referenced column(s) on both sides of the connection. The
-index parent*id_idx is \_required* by the constraint. We can drop that key in our constraint-free table, depending
+index *parent\_id\_idx is required* by the constraint. We can drop that key in our constraint-free table, depending
 on the type of queries we might use to retrieve data from the tables.
 {% /callout %}
 


### PR DESCRIPTION
Fixes the index name in the Tip.

Escapes the `_` in `parent_id_idx`.
Not necessary, but a small thing.

Affected doc: https://planetscale.com/docs/learn/operating-without-foreign-key-constraints

Before:
<img width="250" alt="image" src="https://github.com/planetscale/docs/assets/5631091/2467d863-93b1-4492-92ba-8d90df35fbdf">

After:
<img width="250" alt="image" src="https://github.com/planetscale/docs/assets/5631091/4a183153-e7b8-4ce1-8cc1-38e9fd705b37">

Thanks for the awesome product and docs btw ❤️ 
